### PR TITLE
Added URL work around for linux.

### DIFF
--- a/fetch-validator-status/networks.json
+++ b/fetch-validator-status/networks.json
@@ -15,6 +15,10 @@
     "name": "Local von-network",
     "genesisUrl": "http://host.docker.internal:9000/genesis"
   },
+  "vn-linux": {
+    "name": "Linux Local von-network",
+    "genesisUrl": "http://localhost:9000/genesis"
+  },
   "bcd": {
     "name": "BCovrin Dev",
     "genesisUrl": "http://dev.bcovrin.vonx.io/genesis"

--- a/fetch-validator-status/run.sh
+++ b/fetch-validator-status/run.sh
@@ -9,6 +9,10 @@ if [[ "$OSTYPE" == "msys" ]]; then
   terminalEmu="winpty"
 fi
 
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  netArg="--network=host"
+fi
+
 # IM is for "interactive mode" so Docker is run with the "-it" parameter. Probably never needed
 # but it is there. Use "IM=1 run.sh <args>..." to run the Docker container in interactive mode
 if [ -z "${IM+x}" ]; then
@@ -18,7 +22,7 @@ else
 fi
 
 docker build -t fetch_status . > /dev/null 2>&1
-${terminalEmu} docker run --rm ${DOCKER_INTERACTIVE} \
+${terminalEmu} docker run --rm ${netArg} ${DOCKER_INTERACTIVE} \
     -e "GENESIS_PATH=${GENESIS_PATH}" \
     -e "GENESIS_URL=${GENESIS_URL}" \
     -e "SEED=${SEED}" \


### PR DESCRIPTION
http://host.docker.internal:9000/genesis URL don't work for linux.
New entry added to networks.json and added linux os detection to run.sh.

Signed-off-by: Abdulhamit Kumru <abdulhamitkumru@gmail.com>