### PR TITLE
fix(issue-59): fastapi.Path() abuse not possible anymore

### DIFF
--- a/fetch-validator-status/rest_api.py
+++ b/fetch-validator-status/rest_api.py
@@ -77,7 +77,7 @@ async def networks():
     return data
 
 @app.get("/networks/{network}")
-async def network(network: Network = Path(example_network_enum, example=example_network_name, description="The network code."),
+async def network(network: Network = Path(path=example_network_enum, example=example_network_name, description="The network code."),
                   status: bool = Query(False, description="Filter results to status only."), 
                   alerts: bool = Query(False, description="Filter results to alerts only."),
                   seed: Optional[str] = Header(None, description="Your network monitor seed.")):
@@ -87,14 +87,14 @@ async def network(network: Network = Path(example_network_enum, example=example_
     return result
 
 @app.get("/networks/{network}/pool/transactions", response_class=PlainTextResponse)
-async def network(network: Network = Path(example_network_enum, example=example_network_name, description="The network code.")):
+async def network(network: Network = Path(path=example_network_enum, example=example_network_name, description="The network code.")):
     set_plugin_parameters()
     pool, _ = await pool_collection.get_pool(network.value)
     result = await pool.get_transactions()
     return result
 
 @app.get("/networks/{network}/{node}")
-async def node(network: Network = Path(example_network_enum, example=example_network_name, description="The network code."),
+async def node(network: Network = Path(path=example_network_enum, example=example_network_name, description="The network code."),
                node: str = Path(..., example="FoundationBuilder", description="The node name."),
                status: bool = Query(False, description="Filter results to status only."), 
                alerts: bool = Query(False, description="Filter results to alerts only."),


### PR DESCRIPTION
- note that this is backward-compatible to at least fastapi release 0.89.1