### PR TITLE
Fix for decoding hex seed

### DIFF
--- a/fetch-validator-status/DidKey.py
+++ b/fetch-validator-status/DidKey.py
@@ -19,6 +19,8 @@ class DidKey:
     def seed_as_bytes(self):
         if not self.seed or isinstance(self.seed, bytes):
             return self.seed
+        if len(self.seed) == 64:
+            return bytes.fromhex(self.seed)
         if len(self.seed) != 32:
             return base64.b64decode(self.seed)
         return self.seed.encode("ascii")


### PR DESCRIPTION
Using `openssl rand -hex 32` to generate a monitoring DID seed results in a 64 character string, which causes an error when used. This adds a check for a 64 character string and decodes it as hex.