### PR TITLE
Add support for sh in shell command and fix indy-node-monitor image

### DIFF
--- a/fetch-validator-status/Dockerfile
+++ b/fetch-validator-status/Dockerfile
@@ -61,5 +61,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ADD networks.json .
 ADD *.py ./
+ADD plugins ./plugins
 
 ENTRYPOINT ["bash", "-c", "python main.py $@", "--"]

--- a/manage
+++ b/manage
@@ -3,7 +3,7 @@ export MSYS_NO_PATHCONV=1
 export DOCKERHOST=${APPLICATION_URL-$(docker run --rm --net=host eclipse/che-ip)}
 SCRIPT_HOME="$(cd "$(dirname "$0")" && pwd)"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-indy-node-monitor-stack}"
-export APP_NAME="Indy Node Monitoring Stack" 
+export APP_NAME="Indy Node Monitoring Stack"
 set -e
 
 # =================================================================================================================
@@ -16,34 +16,35 @@ Usage:
   $0 [options] [command] [args]
 
 Commands:
-  up|start [service]      - Spin up the ${APP_NAME} environment.
-                            Optionally specify the service to spin up (dependencies will also be spun up).
-  down|stop [service]     - Tear down the ${APP_NAME} environment.
-                            Optionally specify the service to tear down.
-  restart [service]       - Restart the ${APP_NAME} environment.
-                            Optionally specify the service to restart.
-  list-services           - Get a list the services that make up the ${APP_NAME}.
-  logs <service>          - Stream the logs from a given container.
-  shell <service>         - Open a shell on a given container.
-  install-plugin          - Install a Grafana plug-in on the Grafana container.
-                            You must restart the ${APP_NAME} environment for it to be loaded.
+  up|start [service]          - Spin up the ${APP_NAME} environment.
+                                Optionally specify the service to spin up (dependencies will also be spun up).
+  down|stop [service]         - Tear down the ${APP_NAME} environment.
+                                Optionally specify the service to tear down.
+  restart [service]           - Restart the ${APP_NAME} environment.
+                                Optionally specify the service to restart.
+  list-services               - Get a list the services that make up the ${APP_NAME}.
+  logs <service>              - Stream the logs from a given container.
+  shell <service> [bash|sh]   - Open a shell on a given container.
+                                Optional - Specify bash or sh as the shell; defaults to bash.
+  install-plugin              - Install a Grafana plug-in on the Grafana container.
+                                You must restart the ${APP_NAME} environment for it to be loaded.
 
-  delete-data [service]   - Delete the data for a given service, or all services by default.
-                            Useful to clear data from Prometheus and/or InfluxDB when making changes to how the data is collected.
-  clean                   - Cleans up all environment resources.
-                            Deletes data from all services.
-                            Deletes all containers images and prunes any dangling images.
-  influx-cli              - Open a shell to the Influx CLI on the influxdb container
-  flux-repl               - Open a shell to the Flux REPL on the influxdb container
-  build [service]         - Use for troubleshooting builds when making image configuration changes.
-                            Builds container images based on the docker-compose configuration.
-  sed-test                - Run a 'sed' parsing test on your machine.  Helps diagnose issues with the version
-                            of 'sed on some machines.
+  delete-data [service]       - Delete the data for a given service, or all services by default.
+                                Useful to clear data from Prometheus and/or InfluxDB when making changes to how the data is collected.
+  clean                       - Cleans up all environment resources.
+                                Deletes data from all services.
+                                Deletes all containers images and prunes any dangling images.
+  influx-cli                  - Open a shell to the Influx CLI on the influxdb container
+  flux-repl                   - Open a shell to the Flux REPL on the influxdb container
+  build [service]             - Use for troubleshooting builds when making image configuration changes.
+                                Builds container images based on the docker-compose configuration.
+  sed-test                    - Run a 'sed' parsing test on your machine.  Helps diagnose issues with the version
+                                of 'sed on some machines.
 
 Options:
-  -h                      - Print this help documentation.
-  --nightly               - Build/Use 'nightly' Influx images, 'latest' images are built/used by default.
-                            Works with the up|start and restart commands.
+  -h                          - Print this help documentation.
+  --nightly                   - Build/Use 'nightly' Influx images, 'latest' images are built/used by default.
+                                Works with the up|start and restart commands.
 EOF
   exit 1
 }
@@ -173,9 +174,11 @@ function logs() {
 
 function openShell() {
   (
-    if [ ! -z "${@}" ] && isService ${@}; then
-      echoBlue "Connecting remote shell to ${@} (type 'exit' to exit) ..."
-      ${DOCKER_COMPOSE_EXE} exec ${@} /bin/bash
+    service=${1}
+    shellCmd=${2:-bash}
+    if [ ! -z "${service}" ] && isService ${service}; then
+      echoBlue "Connecting remote shell to ${service} (type 'exit' to exit) ..."
+      ${DOCKER_COMPOSE_EXE} exec ${service} ${shellCmd}
     fi
   )
 }
@@ -404,9 +407,9 @@ function sedTest(){
     cat <<-EOF > ${sedTestFile}
 # ===========================================================
 # This is a file to test parsing with 'sed' on your machine.
-#   - All of the blank lines, comments, and leading and 
-#     trailing whitespace should be stripped out of this 
-#     file and you should only be left with the 
+#   - All of the blank lines, comments, and leading and
+#     trailing whitespace should be stripped out of this
+#     file and you should only be left with the
 #     test phrase wrapped in single quotes:
 #
 #     '${testPhrase}'
@@ -449,7 +452,7 @@ EOF
       echoBlue "-----------------------------------------------------------------------------------------------------------------------------------------------------------------"
     cat <<-EOF
 These scripts use 'sed' and regular expression processing.  The default version of 'sed' on MAC does support some of the processing.
-Details can be found here; 
+Details can be found here;
 [Differences between sed on Mac OSX and other "standard" sed?](https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed)
 
 Please install 'gnu-sed'.
@@ -465,7 +468,7 @@ Append this line to your '~\.bashrc' file:
 [[ ":\$PATH:" != *"/usr/local/opt/gnu-sed/libexec/gnubin:"* ]] && export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:\$PATH"
 '''
 
-Also make sure 'usr/local/bin' is at a higher priority on your **PATH** than 'usr/bin'.  You can do this by making sure 'usr/local/bin' is to the left of 'usr/bin', 
+Also make sure 'usr/local/bin' is at a higher priority on your **PATH** than 'usr/bin'.  You can do this by making sure 'usr/local/bin' is to the left of 'usr/bin',
 preceding it in the **PATH** string.  This will ensure that packages installed by Homebrew override system binaries; in this case 'sed'.
 Append this line to your '~\.bashrc' file:
 '''


### PR DESCRIPTION
- Fixes the issue shelling into the prometheus container.
- Fixes issue with plugins missing from the indy-node-monitor image.

Note:
- The main change was made to openShell.  Everything else is whitespace additions or cleanup.